### PR TITLE
Test without requests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,14 @@ jobs:
         node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          site:
+            - 'site/**'
+          database:
+            - 'database/**'
     - name: Checkout
       uses: actions/checkout@v3
 
@@ -30,14 +38,17 @@ jobs:
         cache-dependency-path: site/package-lock.json
 
     - name: Build database
+      if: steps.filter.outputs.database == 'true'
       run: |
         npm ci
-        npm run cli -- --dir ./database/persons --file ./export/tree.json
+        npm run cli -- --dir ./database/persons --file ./export/tree.json --local
 
-    - name: Copy
+    - name: Copy file
+      if: steps.filter.outputs.database == 'true'
       run: cp export/tree.json export/styles.json site/src/js/
 
     - name: Build site
+      if: steps.filter.outputs.site == 'true'
       working-directory: site
       run: |
         npm ci

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,20 +6,30 @@ const { hideBin } = require('yargs/helpers')
 const argv = yargs(hideBin(process.argv))
       .command('dir', 'source directory with YAML files.')
       .command('file', 'path of the resulting JSON file.')
+      .command('local', 'if present, avoids steps that make HTTP requests (useful for CI)')
+      .boolean('local')
       .help()
       .argv;
 
 
-var dir = argv.dir;
-var targetFile = argv.file;
+let dir = argv.dir
+let targetFile = argv.file
+let localOnly = argv.local
 let stylesFile = path.join(path.dirname(targetFile), "styles.json");
 
 console.log("JDP database parsing started.");
-console.log(`Database dir: ${dir}, target file: ${targetFile}, styles file: ${stylesFile}`);
+console.log(`Database dir: ${dir}, target file: ${targetFile}, styles file: ${stylesFile}, local run: ${localOnly}`);
 
 styles = pY.importStylesYAML("database/styles");
 let database = pY.importYAML(dir);
 
-pY.updateSources(database)
-    .then(v => pY.writeJSON(pY.createCYJS(database, styles), targetFile))
+if (localOnly) {
+    console.log("Local run, avoinding external requests")
+    pY.writeJSON(pY.createCYJS(database, styles), targetFile)
+} else {
+    console.log("Regular run, updating sources")
+    pY.updateSources(database)
+        .then(v => pY.writeJSON(pY.createCYJS(database, styles), targetFile))
+}
+
 pY.writeJSON(styles, stylesFile)


### PR DESCRIPTION
Add logic to the scripts to avoid making HTTP calls as a CLI option, to avoid making time-consuming requests during CI checks (that will not make use of the information obtained from those requests anyway).

Add path-based logic to the workflow to only parse the database if the database was changes, and only build the site if the site files were changed.